### PR TITLE
Make tests create all AIO Cluster infrastructure

### DIFF
--- a/internal/services/deviceregistry/device_registry_asset_resource_test.go
+++ b/internal/services/deviceregistry/device_registry_asset_resource_test.go
@@ -3,6 +3,7 @@ package deviceregistry_test
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"os"
 	"testing"
 
@@ -17,18 +18,9 @@ import (
 
 type AssetTestResource struct{}
 
-const (
-	ASSET_CUSTOM_LOCATION_NAME = "ARM_DEVICE_REGISTRY_CUSTOM_LOCATION"
-	ASSET_RESOURCE_GROUP_NAME  = "ARM_DEVICE_REGISTRY_RESOURCE_GROUP"
-)
-
 func TestAccAsset_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_device_registry_asset", "test")
 	r := AssetTestResource{}
-
-	if os.Getenv(ASSET_CUSTOM_LOCATION_NAME) == "" || os.Getenv(ASSET_RESOURCE_GROUP_NAME) == "" {
-		t.Skipf("Skipping test due to missing environment variables %s and/or %s", ASSET_CUSTOM_LOCATION_NAME, ASSET_RESOURCE_GROUP_NAME)
-	}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -52,10 +44,6 @@ func TestAccAsset_basic(t *testing.T) {
 func TestAccAsset_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_device_registry_asset", "test")
 	r := AssetTestResource{}
-
-	if os.Getenv(ASSET_CUSTOM_LOCATION_NAME) == "" || os.Getenv(ASSET_RESOURCE_GROUP_NAME) == "" {
-		t.Skipf("Skipping test due to missing environment variables %s and/or %s", ASSET_CUSTOM_LOCATION_NAME, ASSET_RESOURCE_GROUP_NAME)
-	}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -123,10 +111,6 @@ func TestAccAsset_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_device_registry_asset", "test")
 	r := AssetTestResource{}
 
-	if os.Getenv(ASSET_CUSTOM_LOCATION_NAME) == "" || os.Getenv(ASSET_RESOURCE_GROUP_NAME) == "" {
-		t.Skipf("Skipping test due to missing environment variables %s and/or %s", ASSET_CUSTOM_LOCATION_NAME, ASSET_RESOURCE_GROUP_NAME)
-	}
-
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.basic(data),
@@ -141,10 +125,6 @@ func TestAccAsset_requiresImport(t *testing.T) {
 func TestAccAsset_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_device_registry_asset", "test")
 	r := AssetTestResource{}
-
-	if os.Getenv(ASSET_CUSTOM_LOCATION_NAME) == "" || os.Getenv(ASSET_RESOURCE_GROUP_NAME) == "" {
-		t.Skipf("Skipping test due to missing environment variables %s and/or %s", ASSET_CUSTOM_LOCATION_NAME, ASSET_RESOURCE_GROUP_NAME)
-	}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -231,7 +211,8 @@ func (AssetTestResource) Exists(ctx context.Context, client *clients.Client, sta
 }
 
 func (r AssetTestResource) basic(data acceptance.TestData) string {
-	template := r.template()
+	template := r.template(data)
+
 	return fmt.Sprintf(`
 %s
 
@@ -250,12 +231,15 @@ resource "azurerm_device_registry_asset" "test" {
   enabled           = false
   external_asset_id = "8ZBA6LRHU0A458969"
   location          = "%[3]s"
+	depends_on = [
+		azurerm_linux_virtual_machine.test
+	]
 }
 `, template, data.RandomInteger, data.Locations.Primary)
 }
 
 func (r AssetTestResource) complete(data acceptance.TestData) string {
-	template := r.template()
+	template := r.template(data)
 	return fmt.Sprintf(`
 %s
 
@@ -373,6 +357,9 @@ resource "azurerm_device_registry_asset" "test" {
     topic_path         = "/path/event2"
     topic_retain       = "Keep"
   }
+	depends_on = [
+		azurerm_linux_virtual_machine.test
+	]
 }
 `, template, data.RandomInteger, data.Locations.Primary)
 }
@@ -392,6 +379,9 @@ resource "azurerm_device_registry_asset" "import" {
   enabled                    = azurerm_device_registry_asset.test.enabled
   external_asset_id          = azurerm_device_registry_asset.test.external_asset_id
   location                   = azurerm_device_registry_asset.test.location
+	depends_on = [
+		azurerm_linux_virtual_machine.test
+	]
 }
 
 
@@ -399,16 +389,23 @@ resource "azurerm_device_registry_asset" "import" {
 }
 
 /*
-Creates the terraform template for AzureRm provider and needed constants
+Creates the terraform template for constants needed for the AIO cluster infra.
 */
-func (AssetTestResource) template() string {
-	customLocation := os.Getenv(ASSET_CUSTOM_LOCATION_NAME)
-	resourceGroup := os.Getenv(ASSET_RESOURCE_GROUP_NAME)
-
+func (AssetTestResource) constantsTemplate(data acceptance.TestData) string {
+	// Trim the random value (from acceptance.RandTimeInt which is 18 digits) to 10 digits
+	// to avoid exceeding the maximum length of the storage account name (24 chars max).
+	trimmedRandomInteger := data.RandomInteger % 10000000000
 	return fmt.Sprintf(`
 locals {
-  custom_location_name = "%[1]s"
-  resource_group_name  = "%[2]s"
+  custom_location           = "acctest-cl%[1]d"
+  cluster_name              = "acctest-akcc-%[1]d"
+  storage_account           = "acctestsa%[2]d"
+  schema_registry           = "acctest-sr-%[1]d"
+  schema_registry_namespace = "acctests-rn-%[1]d"
+  resource_group_name       = "adr-acctest-rg-%[1]d"
+  aio_cluster_resource_name = "adr-aio%[1]d"
+  managed_identity_name     = "adr-mi%[1]d"
+  keyvault_name             = "adr-kv%[1]d"
 }
 
 provider "azurerm" {
@@ -416,5 +413,173 @@ provider "azurerm" {
 }
 
 data "azurerm_client_config" "current" {}
-`, customLocation, resourceGroup)
+`, data.RandomInteger, trimmedRandomInteger)
+}
+
+/*
+The terraform template for all the resources needed to create an AIO cluster on a VM
+which the acceptance tests' AssetEndpointProfile resources will be provisioned to.
+*/
+func (r AssetTestResource) template(data acceptance.TestData) string {
+	constantsTemplate := r.constantsTemplate(data)
+	credential := r.getCredentials()
+	provisionTemplate := r.provisionTemplate(data, credential)
+
+	return fmt.Sprintf(`
+%[5]s
+
+resource "azurerm_resource_group" "test" {
+  name     = local.resource_group_name
+  location = "%[2]s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestnw-%[1]d"
+  address_space       = ["10.0.0.0/16"]
+  location            = "%[2]s"
+  resource_group_name = local.resource_group_name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "internal"
+  resource_group_name  = local.resource_group_name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.2.0/24"]
+}
+
+resource "azurerm_public_ip" "test" {
+  name                = "acctestpip-%[1]d"
+  location            = "%[2]s"
+  resource_group_name = local.resource_group_name
+  allocation_method   = "Static"
+}
+
+resource "azurerm_network_interface" "test" {
+  name                = "acctestnic-%[1]d"
+  location            = "%[2]s"
+  resource_group_name = local.resource_group_name
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = azurerm_subnet.test.id
+    private_ip_address_allocation = "Dynamic"
+    public_ip_address_id          = azurerm_public_ip.test.id
+  }
+}
+
+resource "azurerm_network_security_group" "my_terraform_nsg" {
+  name                = "myNetworkSG-%[1]d"
+  location            = "%[2]s"
+  resource_group_name = local.resource_group_name
+  security_rule {
+    name                       = "SSH"
+    priority                   = 1001
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "22"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      security_rule,
+    ]
+  }
+}
+
+resource "azurerm_network_interface_security_group_association" "test" {
+  network_interface_id      = azurerm_network_interface.test.id
+  network_security_group_id = azurerm_network_security_group.my_terraform_nsg.id
+}
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                = "acctestVM-%[1]d"
+  resource_group_name = local.resource_group_name
+  location            = "%[2]s"
+  size                            = "Standard_F8s_v2"
+  admin_username                  = "adminuser"
+  admin_password                  = "%[3]s"
+  provision_vm_agent              = false
+  allow_extension_operations      = false
+  disable_password_authentication = false
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "0001-com-ubuntu-server-jammy"
+    sku       = "22_04-lts"
+    version   = "latest"
+  }
+
+  identity {
+		type = "SystemAssigned"
+  }
+
+	%[4]s
+
+  depends_on = [
+    azurerm_network_interface_security_group_association.test
+  ]
+}
+`, data.RandomInteger, data.Locations.Primary, credential, provisionTemplate, constantsTemplate)
+}
+
+/*
+Copies the scripts and files needed to create and provision the AIO cluster on the VM.
+Then ssh's into the VM and executes the cluster setup scripts.
+*/
+func (r AssetTestResource) provisionTemplate(data acceptance.TestData, credential string) string {
+	// Get client secrets from env vars because we need them
+	// to remote execute az cli commands on the VM.
+	clientId := os.Getenv("ARM_CLIENT_ID")
+	clientSecret := os.Getenv("ARM_CLIENT_SECRET")
+
+	return fmt.Sprintf(`
+connection {
+ 	type     = "ssh"
+ 	host     = azurerm_public_ip.test.ip_address
+	user     = "adminuser"
+	password = "%[1]s"
+}
+
+provisioner "file" {
+	content = templatefile("testdata/setup_aio_cluster.sh.tftpl", {
+		subscription_id     = data.azurerm_client_config.current.subscription_id
+		resource_group_name = azurerm_resource_group.test.name
+		cluster_name        = local.cluster_name
+		location            = azurerm_resource_group.test.location
+		custom_location     = local.custom_location
+		storage_account     = local.storage_account
+		schema_registry     = local.schema_registry
+		schema_registry_namespace = local.schema_registry_namespace
+		aio_cluster_resource_name = local.aio_cluster_resource_name
+		tenant_id           = data.azurerm_client_config.current.tenant_id
+		client_id           = "%[4]s"
+		client_secret       = "%[5]s"
+		managed_identity_name = local.managed_identity_name
+		keyvault_name       = local.keyvault_name
+	})
+	destination = "%[3]s/setup_aio_cluster.sh"
+}
+
+provisioner "remote-exec" {
+	inline = [
+		"sudo sed -i 's/\r$//' %[3]s/setup_aio_cluster.sh",
+		"sudo chmod +x %[3]s/setup_aio_cluster.sh",
+		"sudo bash %[3]s/setup_aio_cluster.sh > %[3]s/agent_log",
+	]
+}
+`, credential, data.RandomInteger, "/home/adminuser", clientId, clientSecret)
+}
+
+// Generates a random password for the VM.
+func (AssetTestResource) getCredentials() string {
+	return fmt.Sprintf("P@$$w0rd%d!", rand.Intn(10000))
 }

--- a/internal/services/deviceregistry/device_registry_asset_resource_test.go
+++ b/internal/services/deviceregistry/device_registry_asset_resource_test.go
@@ -239,8 +239,8 @@ func (r AssetTestResource) basic(data acceptance.TestData) string {
 
 resource "azurerm_device_registry_asset" "test" {
   name                       = "acctest-asset-%[2]d"
-  resource_group_name        = local.resource_group_name
-  extended_location_name     = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${local.resource_group_name}/providers/Microsoft.ExtendedLocation/customLocations/${local.custom_location}"
+  resource_group_name        = azurerm_resource_group.test.name
+  extended_location_name     = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${azurerm_resource_group.test.name}/providers/Microsoft.ExtendedLocation/customLocations/${local.custom_location}"
   extended_location_type     = "CustomLocation"
   asset_endpoint_profile_ref = "myAssetEndpointProfile"
   discovered_asset_refs = [
@@ -266,8 +266,8 @@ func (r AssetTestResource) complete(data acceptance.TestData) string {
 
 resource "azurerm_device_registry_asset" "test" {
   name                       = "acctest-asset-%[2]d"
-  resource_group_name        = local.resource_group_name
-  extended_location_name     = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${local.resource_group_name}/providers/Microsoft.ExtendedLocation/customLocations/${local.custom_location}"
+  resource_group_name        = azurerm_resource_group.test.name
+  extended_location_name     = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${azurerm_resource_group.test.name}/providers/Microsoft.ExtendedLocation/customLocations/${local.custom_location}"
   extended_location_type     = "CustomLocation"
   location                   = "%[3]s"
   asset_endpoint_profile_ref = "myAssetEndpointProfile"

--- a/internal/services/deviceregistry/device_registry_asset_resource_test.go
+++ b/internal/services/deviceregistry/device_registry_asset_resource_test.go
@@ -16,11 +16,20 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
+const (
+	ASSET_ARM_CLIENT_ID     = "ARM_CLIENT_ID"
+	ASSET_ARM_CLIENT_SECRET = "ARM_CLIENT_SECRET"
+)
+
 type AssetTestResource struct{}
 
 func TestAccAsset_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_device_registry_asset", "test")
 	r := AssetTestResource{}
+
+	if os.Getenv(ASSET_ARM_CLIENT_ID) == "" || os.Getenv(ASSET_ARM_CLIENT_SECRET) == "" {
+		t.Skipf("Skipping test due to missing environment variables %s and/or %s", ASSET_ARM_CLIENT_ID, ASSET_ARM_CLIENT_SECRET)
+	}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -44,6 +53,10 @@ func TestAccAsset_basic(t *testing.T) {
 func TestAccAsset_complete(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_device_registry_asset", "test")
 	r := AssetTestResource{}
+
+	if os.Getenv(ASSET_ARM_CLIENT_ID) == "" || os.Getenv(ASSET_ARM_CLIENT_SECRET) == "" {
+		t.Skipf("Skipping test due to missing environment variables %s and/or %s", ASSET_ARM_CLIENT_ID, ASSET_ARM_CLIENT_SECRET)
+	}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -111,6 +124,10 @@ func TestAccAsset_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_device_registry_asset", "test")
 	r := AssetTestResource{}
 
+	if os.Getenv(ASSET_ARM_CLIENT_ID) == "" || os.Getenv(ASSET_ARM_CLIENT_SECRET) == "" {
+		t.Skipf("Skipping test due to missing environment variables %s and/or %s", ASSET_ARM_CLIENT_ID, ASSET_ARM_CLIENT_SECRET)
+	}
+
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.basic(data),
@@ -125,6 +142,10 @@ func TestAccAsset_requiresImport(t *testing.T) {
 func TestAccAsset_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_device_registry_asset", "test")
 	r := AssetTestResource{}
+
+	if os.Getenv(ASSET_ARM_CLIENT_ID) == "" || os.Getenv(ASSET_ARM_CLIENT_SECRET) == "" {
+		t.Skipf("Skipping test due to missing environment variables %s and/or %s", ASSET_ARM_CLIENT_ID, ASSET_ARM_CLIENT_SECRET)
+	}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -219,7 +240,7 @@ func (r AssetTestResource) basic(data acceptance.TestData) string {
 resource "azurerm_device_registry_asset" "test" {
   name                       = "acctest-asset-%[2]d"
   resource_group_name        = local.resource_group_name
-  extended_location_name     = local.custom_location_name
+  extended_location_name     = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${local.resource_group_name}/providers/Microsoft.ExtendedLocation/customLocations/${local.custom_location}"
   extended_location_type     = "CustomLocation"
   asset_endpoint_profile_ref = "myAssetEndpointProfile"
   discovered_asset_refs = [
@@ -231,9 +252,9 @@ resource "azurerm_device_registry_asset" "test" {
   enabled           = false
   external_asset_id = "8ZBA6LRHU0A458969"
   location          = "%[3]s"
-	depends_on = [
-		azurerm_linux_virtual_machine.test
-	]
+  depends_on = [
+    azurerm_linux_virtual_machine.test
+  ]
 }
 `, template, data.RandomInteger, data.Locations.Primary)
 }
@@ -246,7 +267,7 @@ func (r AssetTestResource) complete(data acceptance.TestData) string {
 resource "azurerm_device_registry_asset" "test" {
   name                       = "acctest-asset-%[2]d"
   resource_group_name        = local.resource_group_name
-  extended_location_name     = local.custom_location_name
+  extended_location_name     = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${local.resource_group_name}/providers/Microsoft.ExtendedLocation/customLocations/${local.custom_location}"
   extended_location_type     = "CustomLocation"
   location                   = "%[3]s"
   asset_endpoint_profile_ref = "myAssetEndpointProfile"
@@ -357,9 +378,9 @@ resource "azurerm_device_registry_asset" "test" {
     topic_path         = "/path/event2"
     topic_retain       = "Keep"
   }
-	depends_on = [
-		azurerm_linux_virtual_machine.test
-	]
+  depends_on = [
+    azurerm_linux_virtual_machine.test
+  ]
 }
 `, template, data.RandomInteger, data.Locations.Primary)
 }
@@ -379,12 +400,10 @@ resource "azurerm_device_registry_asset" "import" {
   enabled                    = azurerm_device_registry_asset.test.enabled
   external_asset_id          = azurerm_device_registry_asset.test.external_asset_id
   location                   = azurerm_device_registry_asset.test.location
-	depends_on = [
-		azurerm_linux_virtual_machine.test
-	]
+  depends_on = [
+    azurerm_linux_virtual_machine.test
+  ]
 }
-
-
 `, template)
 }
 
@@ -401,15 +420,20 @@ locals {
   cluster_name              = "acctest-akcc-%[1]d"
   storage_account           = "acctestsa%[2]d"
   schema_registry           = "acctest-sr-%[1]d"
-  schema_registry_namespace = "acctests-rn-%[1]d"
-  resource_group_name       = "adr-acctest-rg-%[1]d"
-  aio_cluster_resource_name = "adr-aio%[1]d"
-  managed_identity_name     = "adr-mi%[1]d"
-  keyvault_name             = "adr-kv%[1]d"
+  schema_registry_namespace = "acctest-rn-%[1]d"
+  resource_group_name       = "acctest-rg-%[1]d"
+  aio_cluster_resource_name = "acctest-aio%[1]d"
+  managed_identity_name     = "acctest-mi%[1]d"
+  keyvault_name             = "acctest-kv%[1]d"
 }
 
 provider "azurerm" {
-  features {}
+  features {
+    resource_group {
+      // RG will contain AIO resources created from VM. So, we don't want to prevent RG deletion which will clean these up.
+      prevent_deletion_if_contains_resources = false
+    }
+  }
 }
 
 data "azurerm_client_config" "current" {}
@@ -437,39 +461,52 @@ resource "azurerm_virtual_network" "test" {
   name                = "acctestnw-%[1]d"
   address_space       = ["10.0.0.0/16"]
   location            = "%[2]s"
-  resource_group_name = local.resource_group_name
+  resource_group_name = azurerm_resource_group.test.name
+  depends_on = [
+    azurerm_resource_group.test
+  ]
 }
 
 resource "azurerm_subnet" "test" {
   name                 = "internal"
-  resource_group_name  = local.resource_group_name
+  resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.0.2.0/24"]
+  depends_on = [
+    azurerm_resource_group.test
+  ]
 }
 
 resource "azurerm_public_ip" "test" {
   name                = "acctestpip-%[1]d"
   location            = "%[2]s"
-  resource_group_name = local.resource_group_name
+  resource_group_name = azurerm_resource_group.test.name
   allocation_method   = "Static"
+  depends_on = [
+    azurerm_resource_group.test
+  ]
 }
 
 resource "azurerm_network_interface" "test" {
   name                = "acctestnic-%[1]d"
   location            = "%[2]s"
-  resource_group_name = local.resource_group_name
+  resource_group_name = azurerm_resource_group.test.name
   ip_configuration {
     name                          = "internal"
     subnet_id                     = azurerm_subnet.test.id
     private_ip_address_allocation = "Dynamic"
     public_ip_address_id          = azurerm_public_ip.test.id
   }
+
+  depends_on = [
+    azurerm_resource_group.test
+  ]
 }
 
 resource "azurerm_network_security_group" "my_terraform_nsg" {
   name                = "myNetworkSG-%[1]d"
   location            = "%[2]s"
-  resource_group_name = local.resource_group_name
+  resource_group_name = azurerm_resource_group.test.name
   security_rule {
     name                       = "SSH"
     priority                   = 1001
@@ -487,17 +524,24 @@ resource "azurerm_network_security_group" "my_terraform_nsg" {
       security_rule,
     ]
   }
+
+  depends_on = [
+    azurerm_resource_group.test
+  ]
 }
 
 resource "azurerm_network_interface_security_group_association" "test" {
   network_interface_id      = azurerm_network_interface.test.id
   network_security_group_id = azurerm_network_security_group.my_terraform_nsg.id
+  depends_on = [
+    azurerm_resource_group.test
+  ]
 }
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                = "acctestVM-%[1]d"
-  resource_group_name = local.resource_group_name
-  location            = "%[2]s"
+  name                            = "acctestVM-%[1]d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = "%[2]s"
   size                            = "Standard_F8s_v2"
   admin_username                  = "adminuser"
   admin_password                  = "%[3]s"
@@ -519,7 +563,7 @@ resource "azurerm_linux_virtual_machine" "test" {
   }
 
   identity {
-		type = "SystemAssigned"
+    type = "SystemAssigned"
   }
 
 	%[4]s
@@ -538,8 +582,8 @@ Then ssh's into the VM and executes the cluster setup scripts.
 func (r AssetTestResource) provisionTemplate(data acceptance.TestData, credential string) string {
 	// Get client secrets from env vars because we need them
 	// to remote execute az cli commands on the VM.
-	clientId := os.Getenv("ARM_CLIENT_ID")
-	clientSecret := os.Getenv("ARM_CLIENT_SECRET")
+	clientId := os.Getenv(ASSET_ARM_CLIENT_ID)
+	clientSecret := os.Getenv(ASSET_ARM_CLIENT_SECRET)
 
 	return fmt.Sprintf(`
 connection {
@@ -573,7 +617,7 @@ provisioner "remote-exec" {
 	inline = [
 		"sudo sed -i 's/\r$//' %[3]s/setup_aio_cluster.sh",
 		"sudo chmod +x %[3]s/setup_aio_cluster.sh",
-		"sudo bash %[3]s/setup_aio_cluster.sh > %[3]s/agent_log",
+		"sudo bash %[3]s/setup_aio_cluster.sh &> %[3]s/agent_log",
 	]
 }
 `, credential, data.RandomInteger, "/home/adminuser", clientId, clientSecret)

--- a/internal/services/deviceregistry/device_registry_assetendpointprofile_resource_test.go
+++ b/internal/services/deviceregistry/device_registry_assetendpointprofile_resource_test.go
@@ -243,8 +243,8 @@ func (r AssetEndpointProfileTestResource) basic(data acceptance.TestData) string
 
 resource "azurerm_device_registry_asset_endpoint_profile" "test" {
   name                                  = "acctest-assetendpointprofile-%[2]d"
-  resource_group_name                   = local.resource_group_name
-  extended_location_name                = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${local.resource_group_name}/providers/Microsoft.ExtendedLocation/customLocations/${local.custom_location}"
+  resource_group_name                   = azurerm_resource_group.test.name
+  extended_location_name                = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${azurerm_resource_group.test.name}/providers/Microsoft.ExtendedLocation/customLocations/${local.custom_location}"
   extended_location_type                = "CustomLocation"
   target_address                        = "opc.tcp://foo"
   endpoint_profile_type                 = "OpcUa"
@@ -265,8 +265,8 @@ func (r AssetEndpointProfileTestResource) completeCertificate(data acceptance.Te
 
 resource "azurerm_device_registry_asset_endpoint_profile" "test" {
   name                                     = "acctest-assetendpointprofile-%[2]d"
-  resource_group_name                      = local.resource_group_name
-  extended_location_name                   = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${local.resource_group_name}/providers/Microsoft.ExtendedLocation/customLocations/${local.custom_location}"
+  resource_group_name                      = azurerm_resource_group.test.name
+  extended_location_name                   = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${azurerm_resource_group.test.name}/providers/Microsoft.ExtendedLocation/customLocations/${local.custom_location}"
   extended_location_type                   = "CustomLocation"
   target_address                           = "opc.tcp://foo"
   endpoint_profile_type                    = "OpcUa"
@@ -293,8 +293,8 @@ func (r AssetEndpointProfileTestResource) completeUsernamePassword(data acceptan
 
 resource "azurerm_device_registry_asset_endpoint_profile" "test" {
   name                                               = "acctest-assetendpointprofile-%[2]d"
-  resource_group_name                                = local.resource_group_name
-  extended_location_name                             = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${local.resource_group_name}/providers/Microsoft.ExtendedLocation/customLocations/${local.custom_location}"
+  resource_group_name                                = azurerm_resource_group.test.name
+  extended_location_name                             = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${azurerm_resource_group.test.name}/providers/Microsoft.ExtendedLocation/customLocations/${local.custom_location}"
   extended_location_type                             = "CustomLocation"
   target_address                                     = "opc.tcp://foo"
   endpoint_profile_type                              = "OpcUa"
@@ -322,8 +322,8 @@ func (r AssetEndpointProfileTestResource) completeAnonymous(data acceptance.Test
 
 resource "azurerm_device_registry_asset_endpoint_profile" "test" {
   name                                  = "acctest-assetendpointprofile-%[2]d"
-  resource_group_name                   = local.resource_group_name
-  extended_location_name                = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${local.resource_group_name}/providers/Microsoft.ExtendedLocation/customLocations/${local.custom_location}"
+  resource_group_name                   = azurerm_resource_group.test.name
+  extended_location_name                = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${azurerm_resource_group.test.name}/providers/Microsoft.ExtendedLocation/customLocations/${local.custom_location}"
   extended_location_type                = "CustomLocation"
   target_address                        = "opc.tcp://foo"
   endpoint_profile_type                 = "OpcUa"

--- a/internal/services/deviceregistry/device_registry_assetendpointprofile_resource_test.go
+++ b/internal/services/deviceregistry/device_registry_assetendpointprofile_resource_test.go
@@ -16,11 +16,20 @@ import (
 	"github.com/hashicorp/terraform-provider-azurerm/utils"
 )
 
+const (
+	ASSET_ENDPOINT_PROFILE_ARM_CLIENT_ID     = "ARM_CLIENT_ID"
+	ASSET_ENDPOINT_PROFILE_ARM_CLIENT_SECRET = "ARM_CLIENT_SECRET"
+)
+
 type AssetEndpointProfileTestResource struct{}
 
 func TestAccAssetEndpointProfile_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_device_registry_asset_endpoint_profile", "test")
 	r := AssetEndpointProfileTestResource{}
+
+	if os.Getenv(ASSET_ENDPOINT_PROFILE_ARM_CLIENT_ID) == "" || os.Getenv(ASSET_ENDPOINT_PROFILE_ARM_CLIENT_SECRET) == "" {
+		t.Skipf("Skipping test due to missing environment variables %s and/or %s", ASSET_ENDPOINT_PROFILE_ARM_CLIENT_ID, ASSET_ENDPOINT_PROFILE_ARM_CLIENT_SECRET)
+	}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -44,6 +53,10 @@ func TestAccAssetEndpointProfile_basic(t *testing.T) {
 func TestAccAssetEndpointProfile_complete_certificate(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_device_registry_asset_endpoint_profile", "test")
 	r := AssetEndpointProfileTestResource{}
+
+	if os.Getenv(ASSET_ENDPOINT_PROFILE_ARM_CLIENT_ID) == "" || os.Getenv(ASSET_ENDPOINT_PROFILE_ARM_CLIENT_SECRET) == "" {
+		t.Skipf("Skipping test due to missing environment variables %s and/or %s", ASSET_ENDPOINT_PROFILE_ARM_CLIENT_ID, ASSET_ENDPOINT_PROFILE_ARM_CLIENT_SECRET)
+	}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -69,6 +82,10 @@ func TestAccAssetEndpointProfile_complete_usernamePassword(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_device_registry_asset_endpoint_profile", "test")
 	r := AssetEndpointProfileTestResource{}
 
+	if os.Getenv(ASSET_ENDPOINT_PROFILE_ARM_CLIENT_ID) == "" || os.Getenv(ASSET_ENDPOINT_PROFILE_ARM_CLIENT_SECRET) == "" {
+		t.Skipf("Skipping test due to missing environment variables %s and/or %s", ASSET_ENDPOINT_PROFILE_ARM_CLIENT_ID, ASSET_ENDPOINT_PROFILE_ARM_CLIENT_SECRET)
+	}
+
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.completeUsernamePassword(data),
@@ -92,6 +109,10 @@ func TestAccAssetEndpointProfile_complete_usernamePassword(t *testing.T) {
 func TestAccAssetEndpointProfile_complete_anonymous(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_device_registry_asset_endpoint_profile", "test")
 	r := AssetEndpointProfileTestResource{}
+
+	if os.Getenv(ASSET_ENDPOINT_PROFILE_ARM_CLIENT_ID) == "" || os.Getenv(ASSET_ENDPOINT_PROFILE_ARM_CLIENT_SECRET) == "" {
+		t.Skipf("Skipping test due to missing environment variables %s and/or %s", ASSET_ENDPOINT_PROFILE_ARM_CLIENT_ID, ASSET_ENDPOINT_PROFILE_ARM_CLIENT_SECRET)
+	}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -117,6 +138,10 @@ func TestAccAssetEndpointProfile_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_device_registry_asset_endpoint_profile", "test")
 	r := AssetEndpointProfileTestResource{}
 
+	if os.Getenv(ASSET_ENDPOINT_PROFILE_ARM_CLIENT_ID) == "" || os.Getenv(ASSET_ENDPOINT_PROFILE_ARM_CLIENT_SECRET) == "" {
+		t.Skipf("Skipping test due to missing environment variables %s and/or %s", ASSET_ENDPOINT_PROFILE_ARM_CLIENT_ID, ASSET_ENDPOINT_PROFILE_ARM_CLIENT_SECRET)
+	}
+
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.basic(data),
@@ -131,6 +156,10 @@ func TestAccAssetEndpointProfile_requiresImport(t *testing.T) {
 func TestAccAssetEndpointProfile_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_device_registry_asset_endpoint_profile", "test")
 	r := AssetEndpointProfileTestResource{}
+
+	if os.Getenv(ASSET_ENDPOINT_PROFILE_ARM_CLIENT_ID) == "" || os.Getenv(ASSET_ENDPOINT_PROFILE_ARM_CLIENT_SECRET) == "" {
+		t.Skipf("Skipping test due to missing environment variables %s and/or %s", ASSET_ENDPOINT_PROFILE_ARM_CLIENT_ID, ASSET_ENDPOINT_PROFILE_ARM_CLIENT_SECRET)
+	}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{ // first create the resource
@@ -221,9 +250,9 @@ resource "azurerm_device_registry_asset_endpoint_profile" "test" {
   endpoint_profile_type                 = "OpcUa"
   discovered_asset_endpoint_profile_ref = "discoveredAssetEndpointProfile123"
   location                              = "%[3]s"
-	depends_on = [
-		azurerm_linux_virtual_machine.test
-	]
+  depends_on = [
+    azurerm_linux_virtual_machine.test
+  ]
 }
 `, template, data.RandomInteger, data.Locations.Primary)
 }
@@ -249,9 +278,9 @@ resource "azurerm_device_registry_asset_endpoint_profile" "test" {
     "sensor" = "temperature,humidity"
   }
   location = "%[3]s"
-	depends_on = [
-		azurerm_linux_virtual_machine.test
-	]
+  depends_on = [
+    azurerm_linux_virtual_machine.test
+  ]
 }
 `, template, data.RandomInteger, data.Locations.Primary)
 }
@@ -278,9 +307,9 @@ resource "azurerm_device_registry_asset_endpoint_profile" "test" {
     "sensor" = "temperature,humidity"
   }
   location = "%[3]s"
-	depends_on = [
-		azurerm_linux_virtual_machine.test
-	]
+  depends_on = [
+    azurerm_linux_virtual_machine.test
+  ]
 }
 `, template, data.RandomInteger, data.Locations.Primary)
 }
@@ -305,9 +334,9 @@ resource "azurerm_device_registry_asset_endpoint_profile" "test" {
     "sensor" = "temperature,humidity"
   }
   location = "%[3]s"
-	depends_on = [
-		azurerm_linux_virtual_machine.test
-	]
+  depends_on = [
+    azurerm_linux_virtual_machine.test
+  ]
 }
 `, template, data.RandomInteger, data.Locations.Primary)
 }
@@ -326,12 +355,10 @@ resource "azurerm_device_registry_asset_endpoint_profile" "import" {
   endpoint_profile_type                 = azurerm_device_registry_asset_endpoint_profile.test.endpoint_profile_type
   discovered_asset_endpoint_profile_ref = "discoveredAssetEndpointProfile123"
   location                              = azurerm_device_registry_asset_endpoint_profile.test.location
-	depends_on = [
-		azurerm_linux_virtual_machine.test
-	]
+  depends_on = [
+    azurerm_linux_virtual_machine.test
+  ]
 }
-
-
 `, template)
 }
 
@@ -348,15 +375,20 @@ locals {
   cluster_name              = "acctest-akcc-%[1]d"
   storage_account           = "acctestsa%[2]d"
   schema_registry           = "acctest-sr-%[1]d"
-  schema_registry_namespace = "acctests-rn-%[1]d"
-  resource_group_name       = "adr-acctest-rg-%[1]d"
-  aio_cluster_resource_name = "adr-aio%[1]d"
-  managed_identity_name     = "adr-mi%[1]d"
-  keyvault_name             = "adr-kv%[1]d"
+  schema_registry_namespace = "acctest-rn-%[1]d"
+  resource_group_name       = "acctest-rg-%[1]d"
+  aio_cluster_resource_name = "acctest-aio%[1]d"
+  managed_identity_name     = "acctest-mi%[1]d"
+  keyvault_name             = "acctest-kv%[1]d"
 }
 
 provider "azurerm" {
-  features {}
+  features {
+    resource_group {
+      // RG will contain AIO resources created from VM. So, we don't want to prevent RG deletion which will clean these up.
+      prevent_deletion_if_contains_resources = false
+    }
+  }
 }
 
 data "azurerm_client_config" "current" {}
@@ -384,39 +416,52 @@ resource "azurerm_virtual_network" "test" {
   name                = "acctestnw-%[1]d"
   address_space       = ["10.0.0.0/16"]
   location            = "%[2]s"
-  resource_group_name = local.resource_group_name
+  resource_group_name = azurerm_resource_group.test.name
+  depends_on = [
+    azurerm_resource_group.test
+  ]
 }
 
 resource "azurerm_subnet" "test" {
   name                 = "internal"
-  resource_group_name  = local.resource_group_name
+  resource_group_name  = azurerm_resource_group.test.name
   virtual_network_name = azurerm_virtual_network.test.name
   address_prefixes     = ["10.0.2.0/24"]
+  depends_on = [
+    azurerm_resource_group.test
+  ]
 }
 
 resource "azurerm_public_ip" "test" {
   name                = "acctestpip-%[1]d"
   location            = "%[2]s"
-  resource_group_name = local.resource_group_name
+  resource_group_name = azurerm_resource_group.test.name
   allocation_method   = "Static"
+  depends_on = [
+    azurerm_resource_group.test
+  ]
 }
 
 resource "azurerm_network_interface" "test" {
   name                = "acctestnic-%[1]d"
   location            = "%[2]s"
-  resource_group_name = local.resource_group_name
+  resource_group_name = azurerm_resource_group.test.name
   ip_configuration {
     name                          = "internal"
     subnet_id                     = azurerm_subnet.test.id
     private_ip_address_allocation = "Dynamic"
     public_ip_address_id          = azurerm_public_ip.test.id
   }
+
+  depends_on = [
+    azurerm_resource_group.test
+  ]
 }
 
 resource "azurerm_network_security_group" "my_terraform_nsg" {
   name                = "myNetworkSG-%[1]d"
   location            = "%[2]s"
-  resource_group_name = local.resource_group_name
+  resource_group_name = azurerm_resource_group.test.name
   security_rule {
     name                       = "SSH"
     priority                   = 1001
@@ -434,17 +479,24 @@ resource "azurerm_network_security_group" "my_terraform_nsg" {
       security_rule,
     ]
   }
+
+  depends_on = [
+    azurerm_resource_group.test
+  ]
 }
 
 resource "azurerm_network_interface_security_group_association" "test" {
   network_interface_id      = azurerm_network_interface.test.id
   network_security_group_id = azurerm_network_security_group.my_terraform_nsg.id
+  depends_on = [
+    azurerm_resource_group.test
+  ]
 }
 
 resource "azurerm_linux_virtual_machine" "test" {
-  name                = "acctestVM-%[1]d"
-  resource_group_name = local.resource_group_name
-  location            = "%[2]s"
+  name                            = "acctestVM-%[1]d"
+  resource_group_name             = azurerm_resource_group.test.name
+  location                        = "%[2]s"
   size                            = "Standard_F8s_v2"
   admin_username                  = "adminuser"
   admin_password                  = "%[3]s"
@@ -466,7 +518,7 @@ resource "azurerm_linux_virtual_machine" "test" {
   }
 
   identity {
-		type = "SystemAssigned"
+    type = "SystemAssigned"
   }
 
 	%[4]s
@@ -485,8 +537,8 @@ Then ssh's into the VM and executes the cluster setup scripts.
 func (r AssetEndpointProfileTestResource) provisionTemplate(data acceptance.TestData, credential string) string {
 	// Get client secrets from env vars because we need them
 	// to remote execute az cli commands on the VM.
-	clientId := os.Getenv("ARM_CLIENT_ID")
-	clientSecret := os.Getenv("ARM_CLIENT_SECRET")
+	clientId := os.Getenv(ASSET_ENDPOINT_PROFILE_ARM_CLIENT_ID)
+	clientSecret := os.Getenv(ASSET_ENDPOINT_PROFILE_ARM_CLIENT_SECRET)
 
 	return fmt.Sprintf(`
 connection {
@@ -520,7 +572,7 @@ provisioner "remote-exec" {
 	inline = [
 		"sudo sed -i 's/\r$//' %[3]s/setup_aio_cluster.sh",
 		"sudo chmod +x %[3]s/setup_aio_cluster.sh",
-		"sudo bash %[3]s/setup_aio_cluster.sh > %[3]s/agent_log",
+		"sudo bash %[3]s/setup_aio_cluster.sh &> %[3]s/agent_log",
 	]
 }
 `, credential, data.RandomInteger, "/home/adminuser", clientId, clientSecret)

--- a/internal/services/deviceregistry/device_registry_assetendpointprofile_resource_test.go
+++ b/internal/services/deviceregistry/device_registry_assetendpointprofile_resource_test.go
@@ -3,6 +3,7 @@ package deviceregistry_test
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"os"
 	"testing"
 
@@ -17,18 +18,9 @@ import (
 
 type AssetEndpointProfileTestResource struct{}
 
-const (
-	ASSET_ENDPOINT_PROFILE_CUSTOM_LOCATION_NAME = "ARM_DEVICE_REGISTRY_CUSTOM_LOCATION"
-	ASSET_ENDPOINT_PROFILE_RESOURCE_GROUP_NAME  = "ARM_DEVICE_REGISTRY_RESOURCE_GROUP"
-)
-
 func TestAccAssetEndpointProfile_basic(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_device_registry_asset_endpoint_profile", "test")
 	r := AssetEndpointProfileTestResource{}
-
-	if os.Getenv(ASSET_ENDPOINT_PROFILE_CUSTOM_LOCATION_NAME) == "" || os.Getenv(ASSET_ENDPOINT_PROFILE_RESOURCE_GROUP_NAME) == "" {
-		t.Skipf("Skipping test due to missing environment variables %s and/or %s", ASSET_ENDPOINT_PROFILE_CUSTOM_LOCATION_NAME, ASSET_ENDPOINT_PROFILE_RESOURCE_GROUP_NAME)
-	}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -52,10 +44,6 @@ func TestAccAssetEndpointProfile_basic(t *testing.T) {
 func TestAccAssetEndpointProfile_complete_certificate(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_device_registry_asset_endpoint_profile", "test")
 	r := AssetEndpointProfileTestResource{}
-
-	if os.Getenv(ASSET_ENDPOINT_PROFILE_CUSTOM_LOCATION_NAME) == "" || os.Getenv(ASSET_ENDPOINT_PROFILE_RESOURCE_GROUP_NAME) == "" {
-		t.Skipf("Skipping test due to missing environment variables %s and/or %s", ASSET_ENDPOINT_PROFILE_CUSTOM_LOCATION_NAME, ASSET_ENDPOINT_PROFILE_RESOURCE_GROUP_NAME)
-	}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -81,10 +69,6 @@ func TestAccAssetEndpointProfile_complete_usernamePassword(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_device_registry_asset_endpoint_profile", "test")
 	r := AssetEndpointProfileTestResource{}
 
-	if os.Getenv(ASSET_ENDPOINT_PROFILE_CUSTOM_LOCATION_NAME) == "" || os.Getenv(ASSET_ENDPOINT_PROFILE_RESOURCE_GROUP_NAME) == "" {
-		t.Skipf("Skipping test due to missing environment variables %s and/or %s", ASSET_ENDPOINT_PROFILE_CUSTOM_LOCATION_NAME, ASSET_ENDPOINT_PROFILE_RESOURCE_GROUP_NAME)
-	}
-
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.completeUsernamePassword(data),
@@ -108,10 +92,6 @@ func TestAccAssetEndpointProfile_complete_usernamePassword(t *testing.T) {
 func TestAccAssetEndpointProfile_complete_anonymous(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_device_registry_asset_endpoint_profile", "test")
 	r := AssetEndpointProfileTestResource{}
-
-	if os.Getenv(ASSET_ENDPOINT_PROFILE_CUSTOM_LOCATION_NAME) == "" || os.Getenv(ASSET_ENDPOINT_PROFILE_RESOURCE_GROUP_NAME) == "" {
-		t.Skipf("Skipping test due to missing environment variables %s and/or %s", ASSET_ENDPOINT_PROFILE_CUSTOM_LOCATION_NAME, ASSET_ENDPOINT_PROFILE_RESOURCE_GROUP_NAME)
-	}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
@@ -137,10 +117,6 @@ func TestAccAssetEndpointProfile_requiresImport(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_device_registry_asset_endpoint_profile", "test")
 	r := AssetEndpointProfileTestResource{}
 
-	if os.Getenv(ASSET_ENDPOINT_PROFILE_CUSTOM_LOCATION_NAME) == "" || os.Getenv(ASSET_ENDPOINT_PROFILE_RESOURCE_GROUP_NAME) == "" {
-		t.Skipf("Skipping test due to missing environment variables %s and/or %s", ASSET_ENDPOINT_PROFILE_CUSTOM_LOCATION_NAME, ASSET_ENDPOINT_PROFILE_RESOURCE_GROUP_NAME)
-	}
-
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{
 			Config: r.basic(data),
@@ -155,10 +131,6 @@ func TestAccAssetEndpointProfile_requiresImport(t *testing.T) {
 func TestAccAssetEndpointProfile_update(t *testing.T) {
 	data := acceptance.BuildTestData(t, "azurerm_device_registry_asset_endpoint_profile", "test")
 	r := AssetEndpointProfileTestResource{}
-
-	if os.Getenv(ASSET_ENDPOINT_PROFILE_CUSTOM_LOCATION_NAME) == "" || os.Getenv(ASSET_ENDPOINT_PROFILE_RESOURCE_GROUP_NAME) == "" {
-		t.Skipf("Skipping test due to missing environment variables %s and/or %s", ASSET_ENDPOINT_PROFILE_CUSTOM_LOCATION_NAME, ASSET_ENDPOINT_PROFILE_RESOURCE_GROUP_NAME)
-	}
 
 	data.ResourceTest(t, r, []acceptance.TestStep{
 		{ // first create the resource
@@ -235,32 +207,37 @@ func (AssetEndpointProfileTestResource) Exists(ctx context.Context, client *clie
 }
 
 func (r AssetEndpointProfileTestResource) basic(data acceptance.TestData) string {
-	template := r.template()
+	template := r.template(data)
+
 	return fmt.Sprintf(`
 %s
 
 resource "azurerm_device_registry_asset_endpoint_profile" "test" {
   name                                  = "acctest-assetendpointprofile-%[2]d"
   resource_group_name                   = local.resource_group_name
-  extended_location_name                = local.custom_location_name
+  extended_location_name                = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${local.resource_group_name}/providers/Microsoft.ExtendedLocation/customLocations/${local.custom_location}"
   extended_location_type                = "CustomLocation"
   target_address                        = "opc.tcp://foo"
   endpoint_profile_type                 = "OpcUa"
   discovered_asset_endpoint_profile_ref = "discoveredAssetEndpointProfile123"
   location                              = "%[3]s"
+	depends_on = [
+		azurerm_linux_virtual_machine.test
+	]
 }
 `, template, data.RandomInteger, data.Locations.Primary)
 }
 
 func (r AssetEndpointProfileTestResource) completeCertificate(data acceptance.TestData) string {
-	template := r.template()
+	template := r.template(data)
+
 	return fmt.Sprintf(`
 %s
 
 resource "azurerm_device_registry_asset_endpoint_profile" "test" {
   name                                     = "acctest-assetendpointprofile-%[2]d"
   resource_group_name                      = local.resource_group_name
-  extended_location_name                   = local.custom_location_name
+  extended_location_name                   = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${local.resource_group_name}/providers/Microsoft.ExtendedLocation/customLocations/${local.custom_location}"
   extended_location_type                   = "CustomLocation"
   target_address                           = "opc.tcp://foo"
   endpoint_profile_type                    = "OpcUa"
@@ -272,19 +249,23 @@ resource "azurerm_device_registry_asset_endpoint_profile" "test" {
     "sensor" = "temperature,humidity"
   }
   location = "%[3]s"
+	depends_on = [
+		azurerm_linux_virtual_machine.test
+	]
 }
 `, template, data.RandomInteger, data.Locations.Primary)
 }
 
 func (r AssetEndpointProfileTestResource) completeUsernamePassword(data acceptance.TestData) string {
-	template := r.template()
+	template := r.template(data)
+
 	return fmt.Sprintf(`
 %s
 
 resource "azurerm_device_registry_asset_endpoint_profile" "test" {
   name                                               = "acctest-assetendpointprofile-%[2]d"
   resource_group_name                                = local.resource_group_name
-  extended_location_name                             = local.custom_location_name
+  extended_location_name                             = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${local.resource_group_name}/providers/Microsoft.ExtendedLocation/customLocations/${local.custom_location}"
   extended_location_type                             = "CustomLocation"
   target_address                                     = "opc.tcp://foo"
   endpoint_profile_type                              = "OpcUa"
@@ -297,19 +278,23 @@ resource "azurerm_device_registry_asset_endpoint_profile" "test" {
     "sensor" = "temperature,humidity"
   }
   location = "%[3]s"
+	depends_on = [
+		azurerm_linux_virtual_machine.test
+	]
 }
 `, template, data.RandomInteger, data.Locations.Primary)
 }
 
 func (r AssetEndpointProfileTestResource) completeAnonymous(data acceptance.TestData) string {
-	template := r.template()
+	template := r.template(data)
+
 	return fmt.Sprintf(`
 %s
 
 resource "azurerm_device_registry_asset_endpoint_profile" "test" {
   name                                  = "acctest-assetendpointprofile-%[2]d"
   resource_group_name                   = local.resource_group_name
-  extended_location_name                = local.custom_location_name
+  extended_location_name                = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${local.resource_group_name}/providers/Microsoft.ExtendedLocation/customLocations/${local.custom_location}"
   extended_location_type                = "CustomLocation"
   target_address                        = "opc.tcp://foo"
   endpoint_profile_type                 = "OpcUa"
@@ -320,6 +305,9 @@ resource "azurerm_device_registry_asset_endpoint_profile" "test" {
     "sensor" = "temperature,humidity"
   }
   location = "%[3]s"
+	depends_on = [
+		azurerm_linux_virtual_machine.test
+	]
 }
 `, template, data.RandomInteger, data.Locations.Primary)
 }
@@ -336,8 +324,11 @@ resource "azurerm_device_registry_asset_endpoint_profile" "import" {
   extended_location_type                = azurerm_device_registry_asset_endpoint_profile.test.extended_location_type
   target_address                        = azurerm_device_registry_asset_endpoint_profile.test.target_address
   endpoint_profile_type                 = azurerm_device_registry_asset_endpoint_profile.test.endpoint_profile_type
-  discovered_asset_endpoint_profile_ref = azurerm_device_registry_asset_endpoint_profile.test.discovered_asset_endpoint_profile_ref
+  discovered_asset_endpoint_profile_ref = "discoveredAssetEndpointProfile123"
   location                              = azurerm_device_registry_asset_endpoint_profile.test.location
+	depends_on = [
+		azurerm_linux_virtual_machine.test
+	]
 }
 
 
@@ -345,16 +336,23 @@ resource "azurerm_device_registry_asset_endpoint_profile" "import" {
 }
 
 /*
-Creates the terraform template for AzureRm provider and needed constants
+Creates the terraform template for constants needed for the AIO cluster infra.
 */
-func (AssetEndpointProfileTestResource) template() string {
-	customLocation := os.Getenv(ASSET_ENDPOINT_PROFILE_CUSTOM_LOCATION_NAME)
-	resourceGroup := os.Getenv(ASSET_ENDPOINT_PROFILE_RESOURCE_GROUP_NAME)
-
+func (AssetEndpointProfileTestResource) constantsTemplate(data acceptance.TestData) string {
+	// Trim the random value (from acceptance.RandTimeInt which is 18 digits) to 10 digits
+	// to avoid exceeding the maximum length of the storage account name (24 chars max).
+	trimmedRandomInteger := data.RandomInteger % 10000000000
 	return fmt.Sprintf(`
 locals {
-  custom_location_name = "%[1]s"
-  resource_group_name  = "%[2]s"
+  custom_location           = "acctest-cl%[1]d"
+  cluster_name              = "acctest-akcc-%[1]d"
+  storage_account           = "acctestsa%[2]d"
+  schema_registry           = "acctest-sr-%[1]d"
+  schema_registry_namespace = "acctests-rn-%[1]d"
+  resource_group_name       = "adr-acctest-rg-%[1]d"
+  aio_cluster_resource_name = "adr-aio%[1]d"
+  managed_identity_name     = "adr-mi%[1]d"
+  keyvault_name             = "adr-kv%[1]d"
 }
 
 provider "azurerm" {
@@ -362,5 +360,173 @@ provider "azurerm" {
 }
 
 data "azurerm_client_config" "current" {}
-`, customLocation, resourceGroup)
+`, data.RandomInteger, trimmedRandomInteger)
+}
+
+/*
+The terraform template for all the resources needed to create an AIO cluster on a VM
+which the acceptance tests' AssetEndpointProfile resources will be provisioned to.
+*/
+func (r AssetEndpointProfileTestResource) template(data acceptance.TestData) string {
+	constantsTemplate := r.constantsTemplate(data)
+	credential := r.getCredentials()
+	provisionTemplate := r.provisionTemplate(data, credential)
+
+	return fmt.Sprintf(`
+%[5]s
+
+resource "azurerm_resource_group" "test" {
+  name     = local.resource_group_name
+  location = "%[2]s"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestnw-%[1]d"
+  address_space       = ["10.0.0.0/16"]
+  location            = "%[2]s"
+  resource_group_name = local.resource_group_name
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "internal"
+  resource_group_name  = local.resource_group_name
+  virtual_network_name = azurerm_virtual_network.test.name
+  address_prefixes     = ["10.0.2.0/24"]
+}
+
+resource "azurerm_public_ip" "test" {
+  name                = "acctestpip-%[1]d"
+  location            = "%[2]s"
+  resource_group_name = local.resource_group_name
+  allocation_method   = "Static"
+}
+
+resource "azurerm_network_interface" "test" {
+  name                = "acctestnic-%[1]d"
+  location            = "%[2]s"
+  resource_group_name = local.resource_group_name
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = azurerm_subnet.test.id
+    private_ip_address_allocation = "Dynamic"
+    public_ip_address_id          = azurerm_public_ip.test.id
+  }
+}
+
+resource "azurerm_network_security_group" "my_terraform_nsg" {
+  name                = "myNetworkSG-%[1]d"
+  location            = "%[2]s"
+  resource_group_name = local.resource_group_name
+  security_rule {
+    name                       = "SSH"
+    priority                   = 1001
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "22"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      security_rule,
+    ]
+  }
+}
+
+resource "azurerm_network_interface_security_group_association" "test" {
+  network_interface_id      = azurerm_network_interface.test.id
+  network_security_group_id = azurerm_network_security_group.my_terraform_nsg.id
+}
+
+resource "azurerm_linux_virtual_machine" "test" {
+  name                = "acctestVM-%[1]d"
+  resource_group_name = local.resource_group_name
+  location            = "%[2]s"
+  size                            = "Standard_F8s_v2"
+  admin_username                  = "adminuser"
+  admin_password                  = "%[3]s"
+  provision_vm_agent              = false
+  allow_extension_operations      = false
+  disable_password_authentication = false
+  network_interface_ids = [
+    azurerm_network_interface.test.id,
+  ]
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "0001-com-ubuntu-server-jammy"
+    sku       = "22_04-lts"
+    version   = "latest"
+  }
+
+  identity {
+		type = "SystemAssigned"
+  }
+
+	%[4]s
+
+  depends_on = [
+    azurerm_network_interface_security_group_association.test
+  ]
+}
+`, data.RandomInteger, data.Locations.Primary, credential, provisionTemplate, constantsTemplate)
+}
+
+/*
+Copies the scripts and files needed to create and provision the AIO cluster on the VM.
+Then ssh's into the VM and executes the cluster setup scripts.
+*/
+func (r AssetEndpointProfileTestResource) provisionTemplate(data acceptance.TestData, credential string) string {
+	// Get client secrets from env vars because we need them
+	// to remote execute az cli commands on the VM.
+	clientId := os.Getenv("ARM_CLIENT_ID")
+	clientSecret := os.Getenv("ARM_CLIENT_SECRET")
+
+	return fmt.Sprintf(`
+connection {
+ 	type     = "ssh"
+ 	host     = azurerm_public_ip.test.ip_address
+	user     = "adminuser"
+	password = "%[1]s"
+}
+
+provisioner "file" {
+	content = templatefile("testdata/setup_aio_cluster.sh.tftpl", {
+		subscription_id     = data.azurerm_client_config.current.subscription_id
+		resource_group_name = azurerm_resource_group.test.name
+		cluster_name        = local.cluster_name
+		location            = azurerm_resource_group.test.location
+		custom_location     = local.custom_location
+		storage_account     = local.storage_account
+		schema_registry     = local.schema_registry
+		schema_registry_namespace = local.schema_registry_namespace
+		aio_cluster_resource_name = local.aio_cluster_resource_name
+		tenant_id           = data.azurerm_client_config.current.tenant_id
+		client_id           = "%[4]s"
+		client_secret       = "%[5]s"
+		managed_identity_name = local.managed_identity_name
+		keyvault_name       = local.keyvault_name
+	})
+	destination = "%[3]s/setup_aio_cluster.sh"
+}
+
+provisioner "remote-exec" {
+	inline = [
+		"sudo sed -i 's/\r$//' %[3]s/setup_aio_cluster.sh",
+		"sudo chmod +x %[3]s/setup_aio_cluster.sh",
+		"sudo bash %[3]s/setup_aio_cluster.sh > %[3]s/agent_log",
+	]
+}
+`, credential, data.RandomInteger, "/home/adminuser", clientId, clientSecret)
+}
+
+// Generates a random password for the VM.
+func (AssetEndpointProfileTestResource) getCredentials() string {
+	return fmt.Sprintf("P@$$w0rd%d!", rand.Intn(10000))
 }

--- a/internal/services/deviceregistry/testdata/setup_aio_cluster.sh.tftpl
+++ b/internal/services/deviceregistry/testdata/setup_aio_cluster.sh.tftpl
@@ -1,0 +1,108 @@
+#!/bin/bash
+
+export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+export SUBSCRIPTION_ID=${subscription_id}
+export RESOURCE_GROUP=${resource_group_name}
+export CLUSTER_NAME=${cluster_name}
+export LOCATION=${location}
+export AIO_CLUSTER_NAME=${aio_cluster_resource_name}
+export AIO_CLUSTER_CUSTOM_LOCATION_NAME=${custom_location}
+export STORAGE_ACCOUNT_NAME=${storage_account}
+export SCHEMA_REGISTRY_NAME=${schema_registry}
+export SCHEMA_REGISTRY_NAMESPACE=${schema_registry_namespace}
+export TENANT_ID=${tenant_id}
+export USER_ASSIGNED_MI_NAME=${managed_identity_name}
+export KEYVAULT_NAME=${keyvault_name}
+
+## Optional: (only uncomment if you plan to use managed identity or service principal for the `az login` step
+# export AZURE_CLIENT_ID=${client_id} # managed identity or service principal client id
+# export AZURE_CLIENT_SECRET=${client_secret} # service principal client secret (do not uncomment if managed identity)
+
+printf "Subscription ID: $SUBSCRIPTION_ID\n"
+printf "Resource Group: $RESOURCE_GROUP\n"
+printf "Cluster Name: $CLUSTER_NAME\n"
+printf "Location: $LOCATION\n"
+printf "AIO Cluster Name: $AIO_CLUSTER_NAME\n"
+printf "AIO Cluster Custom Location Name: $AIO_CLUSTER_CUSTOM_LOCATION_NAME\n"
+printf "Storage Account Name: $STORAGE_ACCOUNT_NAME\n"
+printf "Schema Registry Name: $SCHEMA_REGISTRY_NAME\n"
+printf "Schema Registry Namespace: $SCHEMA_REGISTRY_NAMESPACE\n"
+printf "Tenant ID: $TENANT_ID\n"
+printf "Managed Identity Name: $USER_ASSIGNED_MI_NAME\n"
+printf "Key Vault Name: $KEYVAULT_NAME\n"
+printf "Azure Client ID: $AZURE_CLIENT_ID\n"
+
+echo "Installing k3s..."
+curl -sfL https://get.k3s.io | sh -
+
+echo "Installing Helm..."
+curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+
+echo "Installing Azure CLI..."
+curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+
+echo "Configuring k3s..."
+sudo chmod 777 /etc/rancher/k3s/k3s.yaml
+
+echo "Logging in to Azure CLI..."
+## Optional: (comment out below line and then uncomment one of the succeeding two lines for logging in with AZ CLI depending on if you use managed identity or service principal to login)
+# az login
+az login --identity --client-id $AZURE_CLIENT_ID # Managed Identity login
+# az login --client-id $AZURE_CLIENT_ID --password $AZURE_CLIENT_SECRET --service-principal --tenant $TENANT_ID # Service Principal login
+
+echo "Setting Azure subscription..."
+az account set --subscription "$SUBSCRIPTION_ID"
+
+echo "Installing Azure CLI extensions..."
+az extension add --name connectedk8s
+az extension add --name azure-iot-ops
+
+echo "Connecting K3s Cluster to Azure resources..."
+az connectedk8s connect --name $CLUSTER_NAME -l $LOCATION --resource-group $RESOURCE_GROUP --enable-oidc-issuer --enable-workload-identity
+
+echo "Configuring k3s to use Azure AD for service account tokens..."
+SERVICE_ACCOUNT_ISSUER=$(az connectedk8s show --resource-group $RESOURCE_GROUP --name $CLUSTER_NAME --query oidcIssuerProfile.issuerUrl --output tsv)
+sudo tee /etc/rancher/k3s/config.yaml > /dev/null <<EOF
+kube-apiserver-arg:
+- service-account-issuer=$SERVICE_ACCOUNT_ISSUER
+- service-account-max-token-expiration=24h
+EOF
+
+echo "Restarting daemon..."
+systemctl daemon-reload
+
+echo "Restarting k3s..."
+systemctl restart k3s
+
+echo "Getting Azure AD object ID of Azure Arc..."
+export OBJECT_ID=$(az ad sp show --id bc313c14-388c-4e7d-a58e-70017303ee3b --query id -o tsv)
+
+echo "Enabling Azure Arc connectedk8s features and custom location..."
+az connectedk8s enable-features -n $CLUSTER_NAME -g $RESOURCE_GROUP --custom-locations-oid $OBJECT_ID --features cluster-connect custom-locations
+
+echo "Creating Azure storage account..."
+az storage account create --name $STORAGE_ACCOUNT_NAME --resource-group $RESOURCE_GROUP --enable-hierarchical-namespace --verbose
+
+echo "Creating Azure IoT Ops schema registry..."
+az iot ops schema registry create --name $SCHEMA_REGISTRY_NAME --resource-group $RESOURCE_GROUP --registry-namespace $SCHEMA_REGISTRY_NAMESPACE --sa-resource-id $(az storage account show --name $STORAGE_ACCOUNT_NAME --resource-group $RESOURCE_GROUP -o tsv --query id) --verbose
+
+echo "Initializing Azure IoT Ops cluster..."
+az iot ops init  --subscription $SUBSCRIPTION_ID -g $RESOURCE_GROUP --cluster $CLUSTER_NAME --debug --no-progress
+
+echo "Creating Azure IoT Ops cluster..."
+az iot ops create  --subscription $SUBSCRIPTION_ID  -g $RESOURCE_GROUP  --cluster $CLUSTER_NAME --custom-location $AIO_CLUSTER_CUSTOM_LOCATION_NAME  -n $AIO_CLUSTER_NAME  --sr-resource-id $(az iot ops schema registry list -g $RESOURCE_GROUP --query "[?name=='$SCHEMA_REGISTRY_NAME'].id" -o tsv)  --add-insecure-listener --enable-rsync --debug --yes --no-progress
+
+echo "Creating Azure Managed Identity..."
+az identity create --name $USER_ASSIGNED_MI_NAME --resource-group $RESOURCE_GROUP --location $LOCATION --subscription $SUBSCRIPTION_ID
+
+echo "Creating Azure Key Vault..."
+az keyvault create --resource-group $RESOURCE_GROUP --location $LOCATION --name $KEYVAULT_NAME --enable-rbac-authorization
+
+echo "Assigning Key Vault Secrets Officer role to the signed-in user..."
+az role assignment create --role "Key Vault Secrets Officer" --assignee $(az ad signed-in-user show --query id -o tsv) --scope /subscriptions/$SUBSCRIPTION_ID/resourcegroups/$RESOURCE_GROUP/providers/Microsoft.KeyVault/vaults/$KEYVAULT_NAME
+
+echo "Enabling Azure IoT Ops SecretSync..."
+az iot ops secretsync enable  -g $RESOURCE_GROUP  -n $AIO_CLUSTER_NAME  --kv-resource-id $(az keyvault list -g $RESOURCE_GROUP  --query "[?name=='$KEYVAULT_NAME'].id" -o tsv) --mi-user-assigned $(az identity list -g $RESOURCE_GROUP --query  "[?name=='$USER_ASSIGNED_MI_NAME'].id" -o tsv)
+
+echo "Assigning Azure Managed Identity to Azure IoT Ops cluster..."
+az iot ops identity assign  -g $RESOURCE_GROUP  -n $AIO_CLUSTER_NAME  --mi-user-assigned $(az identity list -g $RESOURCE_GROUP --query  "[?name=='$USER_ASSIGNED_MI_NAME'].id" -o tsv)

--- a/internal/services/deviceregistry/testdata/setup_aio_cluster.sh.tftpl
+++ b/internal/services/deviceregistry/testdata/setup_aio_cluster.sh.tftpl
@@ -14,9 +14,8 @@ export TENANT_ID=${tenant_id}
 export USER_ASSIGNED_MI_NAME=${managed_identity_name}
 export KEYVAULT_NAME=${keyvault_name}
 
-## Optional: (only uncomment if you plan to use managed identity or service principal for the `az login` step
-# export AZURE_CLIENT_ID=${client_id} # managed identity or service principal client id
-# export AZURE_CLIENT_SECRET=${client_secret} # service principal client secret (do not uncomment if managed identity)
+export AZURE_CLIENT_ID=${client_id} # managed identity or service principal client id
+export AZURE_CLIENT_SECRET=${client_secret} # service principal client secret
 
 printf "Subscription ID: $SUBSCRIPTION_ID\n"
 printf "Resource Group: $RESOURCE_GROUP\n"
@@ -45,10 +44,7 @@ echo "Configuring k3s..."
 sudo chmod 777 /etc/rancher/k3s/k3s.yaml
 
 echo "Logging in to Azure CLI..."
-## Optional: (comment out below line and then uncomment one of the succeeding two lines for logging in with AZ CLI depending on if you use managed identity or service principal to login)
-# az login
-az login --identity --client-id $AZURE_CLIENT_ID # Managed Identity login
-# az login --client-id $AZURE_CLIENT_ID --password $AZURE_CLIENT_SECRET --service-principal --tenant $TENANT_ID # Service Principal login
+az login --username $AZURE_CLIENT_ID --password $AZURE_CLIENT_SECRET --service-principal --tenant $TENANT_ID # Service Principal login
 
 echo "Setting Azure subscription..."
 az account set --subscription "$SUBSCRIPTION_ID"


### PR DESCRIPTION
This PR is just to squash commit all the commits done to make the asset and AEP resource tests create the VM and AIO cluster in the VM. These steps are flakey because the `remote-exec` of the AZ CLI commands script in the VM is not awaited and the arc-enabled resources are still attempted to be made which fails the tests.